### PR TITLE
fix: change admin key validation from error to warning when not provided

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -80,9 +80,8 @@ func (p *OpenAIProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	}
 
 	if adminKey == "" {
-		resp.Diagnostics.AddError("admin_key is required", "admin_key is required")
-		return
-	} else if !strings.HasPrefix(adminKey, "sk-admin-") {
+		resp.Diagnostics.AddWarning("admin_key is required", "admin_key is required")
+	} else if adminKey != "" && !strings.HasPrefix(adminKey, "sk-admin-") {
 		resp.Diagnostics.AddError("admin_key must start with 'sk-admin-'", "admin_key must start with 'sk-admin-'")
 		return
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -81,7 +81,7 @@ func (p *OpenAIProvider) Configure(ctx context.Context, req provider.ConfigureRe
 
 	if adminKey == "" {
 		resp.Diagnostics.AddWarning("admin_key is required", "admin_key is required")
-	} else if adminKey != "" && !strings.HasPrefix(adminKey, "sk-admin-") {
+	} else if !strings.HasPrefix(adminKey, "sk-admin-") {
 		resp.Diagnostics.AddError("admin_key must start with 'sk-admin-'", "admin_key must start with 'sk-admin-'")
 		return
 	}


### PR DESCRIPTION
Previously, attempting to configure the OpenAI provider with a null `admin_key` would result in an error, making it impossible to use configurations where the admin key might be intentionally unset for certain environments or accounts.

This change:
- Changes the admin_key validation from an error to a warning when not provided
- Only performs the sk-admin- prefix validation when an admin_key is actually provided
- Enables common configurations like: 
```hcl
provider "openai" { 
    admin_key = var.openai_api_key # where var.openai_api_key can be null 
}
```

Fixes: https://github.com/jianyuan/terraform-provider-openai/issues/58